### PR TITLE
Avoid lust/coverage/ to get managed by git

### DIFF
--- a/lust/.gitignore
+++ b/lust/.gitignore
@@ -26,6 +26,7 @@
 .pub-cache/
 .pub/
 /build/
+/coverage/
 
 # Android related
 **/android/**/gradle-wrapper.jar


### PR DESCRIPTION
because lust/coverage/ is not neccessary for the application, we don't need to track that folder.